### PR TITLE
Add Views

### DIFF
--- a/docs/src/hdf5.md
+++ b/docs/src/hdf5.md
@@ -253,14 +253,14 @@ Physical units describing the axes should be, if necessary, attached to the `bin
 
 ## Views
 
-A view is stored as an HDF5 link to another HDF5 dataset or group paired with an index of entries, which may be stored as a mask (array of booleans), entry list (array of integers) or slice list (2/3xn array of integers). The entries are selected by their outer indices (i.e. list of records in a tabular data type without modifying individual records). 
+A view is stored as an HDF5 link to another HDF5 dataset or group paired with an index of entries, which may be stored as anentry list (array of integers) or slice list (nx2/3 array of integers). The entries are selected by their outer indices (i.e. list of records in a tabular data type without modifying individual records). 
 
     GROUP "view_name" {
-        ATTRIBUTE "datatype" = "view{name,mask|entries|slices}"
+        ATTRIBUTE "datatype" = "view{entries|slices}"
         HARDLINK | SOFTLINK | EXTERNALLINK "data" -> DATASET | GROUP "name" { ... }
         DATASET "entries" {
             DATA = [...]
         }
     }
 
-If `entries` is formatted as `mask`, it should have the same length as the dataset or Tablular group pointed to by `data`. If `entries` is formatted as `entries`, it should be a sorted list of non-negative, non-repeating integers with values less than the length of the dataset or Tabular group pointed to by `data`. If `entries` is formatted as `slices`, it should be a sorted list of slices; if 2xn, this will indicate contiguous slices, and if 3xn it will indicate strided slices.
+If `entries` is formatted as `entries`, it should be a sorted list of non-negative, non-repeating integers with values less than the length of the dataset or Tabular group pointed to by `data`. If `entries` is formatted as `slices`, it should be a sorted list of slices; if nx2, this will indicate contiguous slices, and if nx3 it will indicate strided slices.

--- a/docs/src/hdf5.md
+++ b/docs/src/hdf5.md
@@ -250,3 +250,21 @@ Multi-dimensional histograms will have groups `axis_2`, etc., with a multi-dimen
 As an alternative to the range objects mentioned above, a simple 1-dimensional array of monotonically increasing bin edges can be used as `binedges` for an axis, to represent a variable binning.
 
 Physical units describing the axes should be, if necessary, attached to the `binedges` object of each axis.
+
+## Views
+
+A view is stored as an HDF5 link to another HDF5 dataset or group paired with an index of entries, which may be stored as a mask (array of booleans), entry list (array of integers) or slice list (2/3xn array of integers). The entries are selected by their outer indices (i.e. list of records in a tabular data type without modifying individual records). 
+
+    GROUP "view_name" {
+        ATTRIBUTE "datatype" = "view{name,mask|entries|slices}"
+        HARDLINK | SOFTLINK | EXTERNALLINK "data" {
+            DATASET | GROUP "name" {
+                ...
+            }
+        DATASET "entries" {
+            ATTRIBUTE "datatype" = "array<1>{bool} | array<1>{real} | array<1,1>{real}"
+            DATA = [...]
+        }
+    }
+
+If `entries` is formatted as `mask`, it should have the same length as the dataset or Tablular group pointed to by `data`. If `entries` is formatted as `entries`, it should be a sorted list of non-negative, non-repeating integers with values less than the length of the dataset or Tabular group pointed to by `data`. If `entries` is formatted as `slices`, it should be a sorted list of slices; if 2xn, this will indicate contiguous slices, and if 3xn it will indicate strided slices.

--- a/docs/src/hdf5.md
+++ b/docs/src/hdf5.md
@@ -257,12 +257,8 @@ A view is stored as an HDF5 link to another HDF5 dataset or group paired with an
 
     GROUP "view_name" {
         ATTRIBUTE "datatype" = "view{name,mask|entries|slices}"
-        HARDLINK | SOFTLINK | EXTERNALLINK "data" {
-            DATASET | GROUP "name" {
-                ...
-            }
+        HARDLINK | SOFTLINK | EXTERNALLINK "data" -> DATASET | GROUP "name" { ... }
         DATASET "entries" {
-            ATTRIBUTE "datatype" = "array<1>{bool} | array<1>{real} | array<1,1>{real}"
             DATA = [...]
         }
     }


### PR DESCRIPTION
See https://github.com/legend-exp/legend-data-format-specs/issues/13

Views are a new lh5 group type that include a link (soft, hard or external https://docs.h5py.org/en/stable/high/group.html#link-classes) to an existing lh5 dataset or tabular group and an entry list, which may be formatted as a boolean mask, index list, or list of slices. In each case, the indices will only refer to the outer-most dimension (i.e. rows/records) of the linked data.

The purpose of this is to enable efficient on-disk representation of sub-Tables. For example, in the LEGEND event tier for sparse-data mode, the event table is not one-to-one with channel data in other data tiers; this would enable the creation of lh5 groups for each channel that would have this property. Another potential use in LEGEND data would be to record data in each cycle as a single table, and include views for each channel using slices (we could have it both ways!).

When reading this into memory, it should be read as a datatype corresponding to the linked group (so the property of being a view should be invisible to the user). One could imagine two different IO modes: one that constructs the hdf5 dataspace and strictly reads the requested data, and one that caches the full table so that you can read different views without extra IO (it may be worth testing if the HDF5 caching negates the need for this).

Some negotiables:
- Enabling all types of links is not necessary, if there are strong reasons to prefer one
- Slices right now refer to a list of slices; however, pragmatically we may want to allow for only a single slice. HDF5 works well with lists of slices through dataspaces, but when it reads in the data it reads it in the order it is on disk. However, many libraries for data handling do not use lists of slices; if they handle slicing by simply modifying a mask, then they will behave similarly to HDF5. However, if (like numpy) they return a new view of the array, this could get quite nasty (for example merging multiple sliced arrays could end up with a different ordering of elements from HDF5; if there are overlapping slices, it will repeat the element unlike HDF5). Some possible solutions to this include:
  - Only allow a single slice
  - Impose requirements on the slices such as requiring them to be in strict order, have no overlaps, etc.